### PR TITLE
Promote expl3 warnings to errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
+# fail-fast
+
 [![make](https://github.com/yegor256/fail-fast/actions/workflows/l3build.yml/badge.svg)](https://github.com/yegor256/fail-fast/actions/workflows/l3build.yml)
 [![CTAN](https://img.shields.io/ctan/v/fail-fast)](https://ctan.org/pkg/fail-fast)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/yegor256/fail-fast/blob/master/LICENSE.txt)
 
-This LaTeX package helps you make your build more fragile, which is good if you care about quality.
-It will turn every warning into an error and the LaTeX engine will fail with a non-zero exit code.
+This LaTeX package helps you make your build more fragile,
+which is good if you care about quality.
+It will turn every warning into an error
+and the LaTeX engine will fail with a non-zero exit code.
 
 First, [install it](https://en.wikibooks.org/wiki/LaTeX/Installing_Extra_Packages)
 from [CTAN](https://ctan.org/pkg/fail-fast)
@@ -17,7 +21,9 @@ This reference is broken: \ref{foo}
 \end{document}
 ```
 
-Otherwise, you can download [`fail-fast.sty`](https://raw.githubusercontent.com/yegor256/fail-fast/gh-pages/fail-fast/fail-fast.sty) and add to your project.
+Otherwise, you can download
+[`fail-fast.sty`](https://raw.githubusercontent.com/yegor256/fail-fast/gh-pages/fail-fast/fail-fast.sty)
+and add to your project.
 
 If you want to contribute yourself, make a fork, then create a branch,
 then run `l3build ctan` in the root directory.

--- a/fail-fast.dtx
+++ b/fail-fast.dtx
@@ -82,7 +82,10 @@
 % \section{Implementation}
 % \changes{v0.0.1}{2023/07/01}{Initial version, which turns warnings into errors}
 % \changes{v0.0.2}{2023/07/04}{Minor changes in the documentation}
+% \changes{v0.0.3}{2026/07/13}{Promote expl3 warnings to errors too}
 
+% Classic \LaTeXe{} warnings travel through |\GenericWarning|, so the package
+% reroutes them to |\GenericError|:
 %    \begin{macrocode}
 \message{fail-fast: Starting from now all warnings
   are reported as errors^^J}%
@@ -90,6 +93,19 @@
   \GenericError{#1}{#2}{}{This was a warning, now an error}%
 }
 %    \end{macrocode}
+
+% A growing share of \LaTeX{} rides on expl3, whose warnings from
+% |\msg_warning:nn| and its siblings never touch |\GenericWarning|. Redirecting
+% the whole |warning| class to |error| catches every variant at once:
+%    \begin{macrocode}
+\ExplSyntaxOn
+\msg_redirect_class:nn { warning } { error }
+\ExplSyntaxOff
+%    \end{macrocode}
+
+% One family of warnings resists promotion: Overfull and Underfull |\hbox| and
+% |\vbox| reports come straight from the \TeX{} box packer, expose no macro
+% hook, and therefore remain warnings.
 
 % \Finale
 

--- a/testfiles/expl3-warning.luatex.tlg
+++ b/testfiles/expl3-warning.luatex.tlg
@@ -1,6 +1,6 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
-! LaTeX Warning: Reference `foo' on page 1 undefined.
-Type  H <return>  for immediate help.
+! Package fail-fast Error: This expl3 warning must fail the build
+Type <return> to continue.
  ...                                              
-l. ......ce is absent, the build must fail: \ref{foo}
+l. ...\msg_warning:nn { fail-fast } { boom }

--- a/testfiles/expl3-warning.lvt
+++ b/testfiles/expl3-warning.lvt
@@ -1,0 +1,16 @@
+% SPDX-FileCopyrightText: Copyright (c) 2023-2026 Yegor Bugayenko
+% SPDX-License-Identifier: MIT
+
+\input{regression-test.tex}
+\documentclass{article}
+\usepackage{fail-fast}
+\begin{document}
+
+\START
+
+\ExplSyntaxOn
+\msg_new:nnn { fail-fast } { boom } { This~expl3~warning~must~fail~the~build }
+\msg_warning:nn { fail-fast } { boom }
+\ExplSyntaxOff
+
+\END

--- a/testfiles/expl3-warning.tlg
+++ b/testfiles/expl3-warning.tlg
@@ -1,0 +1,9 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+! Package fail-fast Error: This expl3 warning must fail the build
+Type <return> to continue.
+ ...                                              
+l. ...\msg_warning:nn { fail-fast } { boom }
+LaTeX does not know anything more about this error, sorry.
+Try typing <return> to proceed.
+If that doesn't work, type X <return> to quit.

--- a/testfiles/expl3-warning.xetex.tlg
+++ b/testfiles/expl3-warning.xetex.tlg
@@ -1,0 +1,9 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+! Package fail-fast Error: This expl3 warning must fail the build
+Type <return> to continue.
+ ...                                              
+l. ...\msg_warning:nn { fail-fast } { boom }
+LaTeX does not know anything more about this error, sorry.
+Try typing <return> to proceed.
+If that doesn't work, type X <return> to quit.

--- a/testfiles/with-warning.tlg
+++ b/testfiles/with-warning.tlg
@@ -2,5 +2,6 @@ This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 ! LaTeX Warning: Reference `foo' on page 1 undefined.
 Type  H <return>  for immediate help.
- ...
-l. ......e is absent, the build must fail: \ref{foo}
+ ...                                              
+l. ...... is absent, the build must fail: \ref{foo}
+This was a warning, now an error

--- a/testfiles/with-warning.xetex.tlg
+++ b/testfiles/with-warning.xetex.tlg
@@ -2,5 +2,6 @@ This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 ! LaTeX Warning: Reference `foo' on page 1 undefined.
 Type  H <return>  for immediate help.
- ...
-l. ......e is absent, the build must fail: \ref{foo}
+ ...                                              
+l. ...... is absent, the build must fail: \ref{foo}
+This was a warning, now an error

--- a/testfiles/without-warning.luatex.tlg
+++ b/testfiles/without-warning.luatex.tlg
@@ -2,5 +2,5 @@ This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 ! LaTeX Warning: Reference `foo' on page 1 undefined.
 Type  H <return>  for immediate help.
- ...
-l. ......s present, the build must NOT fail: \ref{foo}
+ ...                                              
+l. ...... present, the build must NOT fail: \ref{foo}

--- a/testfiles/without-warning.tlg
+++ b/testfiles/without-warning.tlg
@@ -2,5 +2,6 @@ This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 ! LaTeX Warning: Reference `foo' on page 1 undefined.
 Type  H <return>  for immediate help.
- ...
-l. ......present, the build must NOT fail: \ref{foo}
+ ...                                              
+l. ......resent, the build must NOT fail: \ref{foo}
+This was a warning, now an error

--- a/testfiles/without-warning.xetex.tlg
+++ b/testfiles/without-warning.xetex.tlg
@@ -2,5 +2,6 @@ This is a generated file for the l3build validation system.
 Don't change this file in any respect.
 ! LaTeX Warning: Reference `foo' on page 1 undefined.
 Type  H <return>  for immediate help.
- ...
-l. ......present, the build must NOT fail: \ref{foo}
+ ...                                              
+l. ......resent, the build must NOT fail: \ref{foo}
+This was a warning, now an error


### PR DESCRIPTION
The package only redefined `\GenericWarning`, so warnings coming out of the expl3 message system never got promoted. A document whose sole warning was raised by `\msg_warning:nn` (or any of its siblings) still compiled with a zero exit code, which contradicts the promise to turn every warning into an error. This adds `\msg_redirect_class:nn { warning } { error }`, which reroutes the whole expl3 warning class in one shot and catches every variant, not just the four-argument one.

This matters because more and more of modern LaTeX is written in expl3, where warnings travel through `\msg_warning:...` rather than the classic `\GenericWarning`. Trapping only the LaTeX2e path left the LaTeX3 path wide open.

There is a new `expl3-warning` test that fails without the change and passes with it. I also regenerated the `with-warning` and `without-warning` baselines, which had drifted from current TeX Live output and were already breaking the l3build job on master. One thing worth keeping in mind: Overfull/Underfull `\hbox`/`\vbox` reports come from the TeX box packer, have no macro hook, and cannot be promoted by this technique; that limitation is now noted in the docs.

Closes #34